### PR TITLE
Add realtime output from solver

### DIFF
--- a/ampl.py
+++ b/ampl.py
@@ -53,7 +53,7 @@ class AMPLMagic(Magics):
         self.process = None
         self.entities = {}
 
-    def _read(self):
+    def _read(self, silent=True):
         """Read AMPL output until the next prompt"""
         stdout = self.process.stdout
         out = ""
@@ -70,6 +70,9 @@ class AMPLMagic(Magics):
             # TODO: handle errors
             if command.startswith("prompt"):
                 break
+            if not silent:
+               sys.stdout.write(block);
+               sys.stdout.flush()
             out += block
         return out
 
@@ -164,9 +167,9 @@ class AMPLMagic(Magics):
         try:
             if first_time:
                 # Read the prompt.
-                self._read()
+                self._read(silent=False)
             self._write(cell.encode('utf8', 'replace'))
-            out = self._read()
+            out = self._read(silent=False)
             for set in ["_PARS", "_SETS", "_VARS", "_OBJS", "_CONS"]:
                 for p in self._read_data(set):
                     self._add_entity(p)
@@ -191,11 +194,8 @@ class AMPLMagic(Magics):
                     % (p.pid, e)
             return
 
-        out = py3compat.bytes_to_str(out)
         # TODO: add an option to capture the AMPL output
         # See https://github.com/ipython/ipython/blob/master/IPython/core/magics/script.py
-        sys.stdout.write(out)
-        sys.stdout.flush()
 
 def load_ipython_extension(ip):
     """Load the extension in IPython."""


### PR DESCRIPTION
Hey, great job with this ampl magic for ipython, found it super useful in debugging models/visualizing solutions quickly without having to parse a solution file or use AMPL shell.
I made a small (and ugly) change to get realtime output from the solver showing up inline, not only when the optimization is over, don't know if you like . (Probably should have just filed an issue instead of a pull request? Github noob here.)
By the way, there's an issue when stopping the execution in IPython notebook. 
In a (ipython) shell, Ctrl+C stops AMPL _and_ solver, but in the notebook the solver is left hanging - and keeps eating CPU unless I kill it, or wait for the optimization to end.
